### PR TITLE
fix: 支持自定义指令执行脚本，主要用于适配 Node 绝对路径，与pfork参数一致

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -206,7 +206,7 @@ function execCmd(main, data, options) {
     args.push(encodeURIComponent(JSON.stringify(data)));
   }
 
-  return cp.spawn('node', args, options);
+  return cp.spawn(process.env.PFORK_EXEC_PATH || 'node', args, options);
 }
 
 function readConfig(main) {


### PR DESCRIPTION
绝对路径执行 nohost 时，会出现使用系统 node 版本执行的问题，多 node 版本可能出现问题